### PR TITLE
fix: remove export map

### DIFF
--- a/.changeset/nine-steaks-rhyme.md
+++ b/.changeset/nine-steaks-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/icons": patch
+---
+
+Removed the export map. This should improve compatibility with Webpack.

--- a/package.json
+++ b/package.json
@@ -10,12 +10,6 @@
   "scripts": {
     "build": "ts-node --esm ./scripts/build.ts"
   },
-  "exports": {
-    "./patternfly/*": "./patternfly/*",
-    "./fab/*": "./fab/*",
-    "./far/*": "./far/*",
-    "./fas/*": "./fas/*"
-  },
   "files": [
     "./**/*.js",
     "./**/*.svg",


### PR DESCRIPTION
The existing export map doesn't actually do anything, it just transparently (although explicitly) forwards to the existing paths. Since webpack can't handle this `.`-less export map, we might as well remove it